### PR TITLE
Update tACSChallenge_ImportData.m

### DIFF
--- a/tACSChallenge_ImportData.m
+++ b/tACSChallenge_ImportData.m
@@ -44,6 +44,16 @@ tmp_matrix = tmp_matrix(2:end,:);
 %% Extract Data
 % Delta T
 data_array.raw_dt = diff(tmp_matrix(:,1));
+
+% handle reset of processor clock in teensy during recording
+% check if any dt is negative (step backwards in time)
+if sum(data_array.raw_dt<0) > 0
+    
+    % replace with the mean of all other dt
+    data_array.raw_dt(data_array.raw_dt < 0) =  mean(data_array.raw_dt(data_array.raw_dt > 0),'omitnan');
+    
+end
+
 data_array.dt = mean(data_array.raw_dt,'omitnan')/10^6; %uS to Seconds
 % Sampling Rate
 data_array.Fs = 1/data_array.dt;


### PR DESCRIPTION
I modified the DataImport function such that it checks for negative dt values that indicate a reset of the processor clock during recording. The dt value is then replaced with the mean dt of all other samples.